### PR TITLE
classname for label and fields

### DIFF
--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -1,6 +1,5 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
-
 var validatorPropType = React.PropTypes.shape({
   error: React.PropTypes.string,
   validate: React.PropTypes.func
@@ -124,7 +123,8 @@ var Form = React.createClass({
         label = field.label,
         formfield = null,
         hasError = this.state.errorElements.indexOf(name) !== -1,
-        inputClass = hasError ? 'error' : '';
+        labelClass = field.labelClassname ? field.labelClassname : '',
+        inputClass = hasError ? `error ${field.fieldClassname}` : `${field.fieldClassname}`;
 
     var common = {
       key: name + 'field',
@@ -159,7 +159,7 @@ var Form = React.createClass({
     }
 
     if (label) {
-      label = <label key={name + 'label'}>{label}</label>;
+      label = <label key={name + 'label'} className={labelClass}>{label}</label>;
       // mark optional fields that have a label as being optional:
       if (field.optional) {
         label = [label, <span key={name + 'label-optional'} > (optional)</span>];
@@ -178,7 +178,7 @@ var Form = React.createClass({
     } else if (Type === "checkbox") {
       // FIXME: while clickable, this does not seem to tick the checkbox...
       formfield = <div>
-        <label>
+        <label className={labelClass}>
           <input className={inputClass} {...common} type="checkbox"/>
           { label }
         </label>
@@ -193,7 +193,7 @@ var Form = React.createClass({
       for (let c=0; c<colCount; c++) {
         let choiceset = choices.slice(c*bracket, (c+1)*bracket).map(value => {
           return <div key={value}>
-            <label>
+            <label className={labelClass}>
               <input className={inputClass} type="radio" name={name} value={value} checked={this.state[name] === value} onChange={common.onChange}/>
               {value}
             </label>
@@ -213,7 +213,7 @@ var Form = React.createClass({
       for (let c=0; c<colCount; c++) {
         let choiceset = choices.slice(c*bracket, (c+1)*bracket).map(value => {
           return <div key={value}>
-            <label>
+            <label className={labelClass}>
               <input className={inputClass} type="checkbox" name={name} value={value} checked={this.state[name].indexOf(value)>-1} onChange={common.onChange}/>
               {value}
             </label>

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -1,5 +1,6 @@
 var React = require('react');
 var ReactDOM = require('react-dom');
+
 var validatorPropType = React.PropTypes.shape({
   error: React.PropTypes.string,
   validate: React.PropTypes.func
@@ -124,7 +125,7 @@ var Form = React.createClass({
         formfield = null,
         hasError = this.state.errorElements.indexOf(name) !== -1,
         labelClass = field.labelClassname ? field.labelClassname : '',
-        inputClass = hasError ? `error ${field.fieldClassname}` : `${field.fieldClassname}`;
+        inputClass = `${hasError ? 'error' : ''} ${field.fieldClassname}`;
 
     var common = {
       key: name + 'field',


### PR DESCRIPTION
Fixes #3

This is built on top of my PR https://github.com/Pomax/react-formbuilder/pull/2

Use case example:
To assign Bootstrap's `.form-control-label` class to `<label>` & `.form-control` class to `<input>`.