### PR TITLE
Add support for an image field

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@ Where a field definition object takes the following form:
 
 ```
 {
-  type: ["text"|"textarea"|"choiceGroup"|"checkbox"|"checkboxGroup"|ReactComponentClass],
+  type: ["image"|text"|"textarea"|"choiceGroup"|"checkbox"|"checkboxGroup"|ReactComponentClass],
   label: String data,
+  fieldClassname: String data (optional) representing a custom CSS class for this field's form element,
+  labelClassname: String data (optional) representing a custom CSS class for this field's label element,
   placeholder: String data (optional)
   metered: boolean (optional),
   optional: boolean (optional),

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Where a field definition object takes the following form:
   multiplicity: number (optional) marking this field as a "there can be more than one of these", with automatic (+)/(-) controls (currently only works with "text" fields). The number provided specifies the default number of fields to show when the form is bootstrapped,
   removeLabel: string (optional) for the "remove" button next to a multiples field,
   addLabel: string (optional) for the "add" button next to a multiples field
+
+  prompt: string (optional) for the "pick a file from your computer" image button
+  reprompt: string (optional) for the "pick a different file from your computer" image button, after initial image selection
 }
 ```
 

--- a/dist/react-formbuilder.js
+++ b/dist/react-formbuilder.js
@@ -984,7 +984,7 @@ var validatorPropType = React.PropTypes.shape({
 });
 
 module.exports = React.PropTypes.shape({
-  type: React.PropTypes.oneOfType([React.PropTypes.oneOf(['text', 'textarea', 'choiceGroup', 'checkbox', 'checkboxGroup']), React.PropTypes.func]).isRequired,
+  type: React.PropTypes.oneOfType([React.PropTypes.oneOf(['image', 'text', 'textarea', 'choiceGroup', 'checkbox', 'checkboxGroup']), React.PropTypes.func]).isRequired,
   label: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.element]),
   placeholder: React.PropTypes.string,
   validator: React.PropTypes.oneOfType([validatorPropType, React.PropTypes.arrayOf(validatorPropType)]),
@@ -1331,26 +1331,91 @@ module.exports = React.createClass({
 "use strict";
 
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
 var React = __webpack_require__(0);
 var cleanProps = __webpack_require__(1);
 var MultiplicityField = __webpack_require__(5);
 
 module.exports = React.createClass({
   displayName: "exports",
+  getInitialState: function getInitialState() {
+    console.log(this.props);
+    return {
+      attachment: false
+    };
+  },
   render: function render() {
-    var props = this.props;
-    var value = props.value;
+    var _this = this;
 
-    if (props.multiplicity) {
-      var values = (typeof value === "undefined" ? "undefined" : _typeof(value)) === "object" ? value : [value];
-      return React.createElement(MultiplicityField, _extends({}, props, { values: values }));
+    var props = this.props;
+    var className = (this.props.className || '') + ' image';
+
+    return React.createElement(
+      "div",
+      { className: className },
+      React.createElement("input", { type: "file", hidden: "hidden", ref: "optionalFile", onChange: function onChange(e) {
+          return _this.handleFiles(e);
+        } }),
+      this.generatePicker()
+    );
+  },
+
+
+  generatePicker: function generatePicker() {
+    var _this2 = this;
+
+    if (!this.state.attachment) {
+      return React.createElement("input", { type: "button", className: "btn attach", onClick: function onClick(e) {
+          return _this2.selectFiles(e);
+        }, value: "Click here to pick an image" });
     }
 
-    return React.createElement("input", _extends({ type: "text" }, cleanProps(props)));
+    return [React.createElement("img", { key: "preview", src: "data:image/jpg;base64," + this.state.attachment.base64 }), React.createElement("input", { key: "attach", type: "button", className: "btn reattach", onClick: function onClick(e) {
+        return _this2.selectFiles(e);
+      }, value: "Click here to pick a different image" })];
+  },
+
+  selectFiles: function selectFiles() {
+    this.refs.optionalFile.click();
+  },
+
+  handleFiles: function handleFiles(evt) {
+    var _this3 = this;
+
+    var files = evt.target.files;
+
+    var attachment = {};
+
+    var parse = function parse(file) {
+      var reader = new FileReader();
+      var bootstrap = function bootstrap(f) {
+        return function (e) {
+          var name = escape(f.name);
+          var data = e.target.result;
+
+          if (data) {
+            data = data.substring(data.indexOf('base64,') + 'base64,'.length);
+            attachment = {
+              name: name,
+              base64: data
+            };
+            _this3.setState({ attachment: attachment }, _this3.handleImageAttached);
+          }
+        };
+      };
+
+      reader.onload = bootstrap(file);
+      reader.readAsDataURL(file);
+    };
+
+    Array.from(files).forEach(parse);
+  },
+
+  handleImageAttached: function handleImageAttached() {
+    this.props.onChange({
+      target: {
+        value: this.state.attachment
+      }
+    });
   }
 });
 

--- a/example/app.compiled.js
+++ b/example/app.compiled.js
@@ -10436,7 +10436,7 @@ var validatorPropType = React.PropTypes.shape({
 });
 
 module.exports = React.PropTypes.shape({
-  type: React.PropTypes.oneOfType([React.PropTypes.oneOf(['text', 'textarea', 'choiceGroup', 'checkbox', 'checkboxGroup']), React.PropTypes.func]).isRequired,
+  type: React.PropTypes.oneOfType([React.PropTypes.oneOf(['image', 'text', 'textarea', 'choiceGroup', 'checkbox', 'checkboxGroup']), React.PropTypes.func]).isRequired,
   label: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.element]),
   placeholder: React.PropTypes.string,
   validator: React.PropTypes.oneOfType([validatorPropType, React.PropTypes.arrayOf(validatorPropType)]),
@@ -10783,26 +10783,91 @@ module.exports = React.createClass({
 "use strict";
 
 
-var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
-
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
-
 var React = __webpack_require__(0);
 var cleanProps = __webpack_require__(1);
 var MultiplicityField = __webpack_require__(5);
 
 module.exports = React.createClass({
   displayName: "exports",
+  getInitialState: function getInitialState() {
+    console.log(this.props);
+    return {
+      attachment: false
+    };
+  },
   render: function render() {
-    var props = this.props;
-    var value = props.value;
+    var _this = this;
 
-    if (props.multiplicity) {
-      var values = (typeof value === "undefined" ? "undefined" : _typeof(value)) === "object" ? value : [value];
-      return React.createElement(MultiplicityField, _extends({}, props, { values: values }));
+    var props = this.props;
+    var className = (this.props.className || '') + ' image';
+
+    return React.createElement(
+      "div",
+      { className: className },
+      React.createElement("input", { type: "file", hidden: "hidden", ref: "optionalFile", onChange: function onChange(e) {
+          return _this.handleFiles(e);
+        } }),
+      this.generatePicker()
+    );
+  },
+
+
+  generatePicker: function generatePicker() {
+    var _this2 = this;
+
+    if (!this.state.attachment) {
+      return React.createElement("input", { type: "button", className: "btn attach", onClick: function onClick(e) {
+          return _this2.selectFiles(e);
+        }, value: "Click here to pick an image" });
     }
 
-    return React.createElement("input", _extends({ type: "text" }, cleanProps(props)));
+    return [React.createElement("img", { key: "preview", src: "data:image/jpg;base64," + this.state.attachment.base64 }), React.createElement("input", { key: "attach", type: "button", className: "btn reattach", onClick: function onClick(e) {
+        return _this2.selectFiles(e);
+      }, value: "Click here to pick a different image" })];
+  },
+
+  selectFiles: function selectFiles() {
+    this.refs.optionalFile.click();
+  },
+
+  handleFiles: function handleFiles(evt) {
+    var _this3 = this;
+
+    var files = evt.target.files;
+
+    var attachment = {};
+
+    var parse = function parse(file) {
+      var reader = new FileReader();
+      var bootstrap = function bootstrap(f) {
+        return function (e) {
+          var name = escape(f.name);
+          var data = e.target.result;
+
+          if (data) {
+            data = data.substring(data.indexOf('base64,') + 'base64,'.length);
+            attachment = {
+              name: name,
+              base64: data
+            };
+            _this3.setState({ attachment: attachment }, _this3.handleImageAttached);
+          }
+        };
+      };
+
+      reader.onload = bootstrap(file);
+      reader.readAsDataURL(file);
+    };
+
+    Array.from(files).forEach(parse);
+  },
+
+  handleImageAttached: function handleImageAttached() {
+    this.props.onChange({
+      target: {
+        value: this.state.attachment
+      }
+    });
   }
 });
 
@@ -10912,6 +10977,11 @@ var MultiSectionedForm = exports.MultiSectionedForm = _MultiSectionedForm2.defau
 
 
 module.exports = {
+  'avatar': {
+    type: "image",
+    label: "Select an avatar",
+    fieldClassname: "avatar"
+  },
   'full_name': {
     type: "text",
     label: "Participant name",

--- a/example/app.compiled.js
+++ b/example/app.compiled.js
@@ -9718,19 +9718,21 @@ var Form = React.createClass({
 
     // Does this field come with an associated label?
     if (label) {
+      var optional = '';
+      // mark optional fields that have a label as being optional:
+      if (field.optional) {
+        optional = React.createElement(
+          'span',
+          { key: name + 'label-optional', className: 'optional' },
+          '(optional)'
+        );
+      }
       label = React.createElement(
         'label',
         { key: name + 'label', className: labelClass },
-        label
+        label,
+        optional
       );
-      // mark optional fields that have a label as being optional:
-      if (field.optional) {
-        label = [label, React.createElement(
-          'span',
-          { key: name + 'label-optional' },
-          ' (optional)'
-        )];
-      }
     } else {
       label = null;
       inputClass += " nolabel";
@@ -10429,25 +10431,30 @@ module.exports = MultiplicityField;
 
 
 var React = __webpack_require__(0);
+var types = React.PropTypes;
 
-var validatorPropType = React.PropTypes.shape({
-  error: React.PropTypes.string,
-  validate: React.PropTypes.func
+var validatorPropType = types.shape({
+  error: types.string,
+  validate: types.func
 });
 
-module.exports = React.PropTypes.shape({
-  type: React.PropTypes.oneOfType([React.PropTypes.oneOf(['image', 'text', 'textarea', 'choiceGroup', 'checkbox', 'checkboxGroup']), React.PropTypes.func]).isRequired,
-  label: React.PropTypes.oneOfType([React.PropTypes.string, React.PropTypes.element]),
-  placeholder: React.PropTypes.string,
-  validator: React.PropTypes.oneOfType([validatorPropType, React.PropTypes.arrayOf(validatorPropType)]),
-  metered: React.PropTypes.boolean,
-  optional: React.PropTypes.boolean,
-  controller: React.PropTypes.shape({
-    name: React.PropTypes.string,
-    value: React.PropTypes.oneOfType([React.PropTypes.bool, React.PropTypes.number, React.PropTypes.string, React.PropTypes.array, React.PropTypes.object])
-  }),
-  colCount: React.PropTypes.number,
-  multiplicity: React.PropTypes.number
+var controllerPropType = {
+  name: types.string,
+  value: types.oneOfType([types.bool, types.number, types.string, types.array, types.object])
+};
+
+module.exports = types.shape({
+  type: types.oneOfType([types.oneOf(['image', 'text', 'textarea', 'choiceGroup', 'checkbox', 'checkboxGroup']), types.func]).isRequired,
+  label: types.oneOfType([types.string, types.element]),
+  placeholder: types.string,
+  validator: types.oneOfType([validatorPropType, types.arrayOf(validatorPropType)]),
+  metered: types.boolean,
+  optional: types.boolean,
+  controller: types.shape(controllerPropType),
+  colCount: types.number,
+  multiplicity: types.number, // used by text
+  prompt: types.string, // used by image
+  reprompt: types.string // used by image
 });
 
 /***/ }),
@@ -10790,7 +10797,6 @@ var MultiplicityField = __webpack_require__(5);
 module.exports = React.createClass({
   displayName: "exports",
   getInitialState: function getInitialState() {
-    console.log(this.props);
     return {
       attachment: false
     };
@@ -10799,67 +10805,67 @@ module.exports = React.createClass({
     var _this = this;
 
     var props = this.props;
-    var className = (this.props.className || '') + ' image';
+    var field = props.field;
+    var className = ((props.className || '') + ' image').trim();
 
     return React.createElement(
       "div",
       { className: className },
-      React.createElement("input", { type: "file", hidden: "hidden", ref: "optionalFile", onChange: function onChange(e) {
+      React.createElement("input", { type: "file", hidden: "hidden", ref: "filePicker", onChange: function onChange(e) {
           return _this.handleFiles(e);
         } }),
-      this.generatePicker()
+      this.generatePicker(field.prompt, field.reprompt)
     );
   },
 
 
-  generatePicker: function generatePicker() {
+  generatePicker: function generatePicker(prompt, reprompt) {
     var _this2 = this;
 
     if (!this.state.attachment) {
+      prompt = prompt || "Click here to pick an image";
+
       return React.createElement("input", { type: "button", className: "btn attach", onClick: function onClick(e) {
           return _this2.selectFiles(e);
-        }, value: "Click here to pick an image" });
+        }, value: prompt });
     }
+
+    reprompt = reprompt || "Click here to pick a different image";
 
     return [React.createElement("img", { key: "preview", src: "data:image/jpg;base64," + this.state.attachment.base64 }), React.createElement("input", { key: "attach", type: "button", className: "btn reattach", onClick: function onClick(e) {
         return _this2.selectFiles(e);
-      }, value: "Click here to pick a different image" })];
+      }, value: reprompt })];
   },
 
   selectFiles: function selectFiles() {
-    this.refs.optionalFile.click();
+    this.refs.filePicker.click();
   },
 
   handleFiles: function handleFiles(evt) {
     var _this3 = this;
 
     var files = evt.target.files;
-
-    var attachment = {};
+    var b64str = 'base64,';
 
     var parse = function parse(file) {
       var reader = new FileReader();
-      var bootstrap = function bootstrap(f) {
-        return function (e) {
-          var name = escape(f.name);
-          var data = e.target.result;
-
+      var fileAsBase64 = function fileAsBase64(selectedFile) {
+        return function (evt) {
+          var name = escape(selectedFile.name);
+          var data = evt.target.result;
           if (data) {
-            data = data.substring(data.indexOf('base64,') + 'base64,'.length);
-            attachment = {
-              name: name,
-              base64: data
-            };
+            var base64 = data.substring(data.indexOf(b64str) + b64str.length);
+            var attachment = { name: name, base64: base64 };
             _this3.setState({ attachment: attachment }, _this3.handleImageAttached);
           }
         };
       };
 
-      reader.onload = bootstrap(file);
+      reader.onload = fileAsBase64(file);
       reader.readAsDataURL(file);
     };
 
-    Array.from(files).forEach(parse);
+    parse(Array.from(files).slice(-1)[0]);
   },
 
   handleImageAttached: function handleImageAttached() {
@@ -10980,7 +10986,9 @@ module.exports = {
   'avatar': {
     type: "image",
     label: "Select an avatar",
-    fieldClassname: "avatar"
+    fieldClassname: "avatar",
+    prompt: "Pick image",
+    reprompt: "Pick different image"
   },
   'full_name': {
     type: "text",
@@ -11025,7 +11033,9 @@ module.exports = {
   },
   'email choices': {
     type: "checkbox",
-    label: "I would like to pick the emails you send me"
+    label: "I would like to pick the emails you send me",
+    metered: false,
+    optional: true
   },
   'email cats': {
     type: "checkboxGroup",
@@ -11035,9 +11045,8 @@ module.exports = {
       name: "email choices",
       value: true
     },
-    validator: {
-      error: "Please pick at least one category of emails you would like to receive."
-    }
+    metered: false,
+    optional: true
   },
   notes: {
     type: "textarea",
@@ -23375,6 +23384,8 @@ var App = function (_React$Component) {
       // used, React throws a controlled/uncontrolled warning... =_=
       var checked = this.state.inlineErrors ? "checked" : false;
 
+      var percentage = parseInt(this.state.ratio * 100);
+
       return React.createElement(
         'div',
         null,
@@ -23395,14 +23406,18 @@ var App = function (_React$Component) {
         React.createElement(
           'span',
           null,
-          this.state.ratio * 100,
+          percentage,
           '%'
         ),
         ' complete)',
-        React.createElement('input', { type: 'checkbox', onChange: function onChange(e) {
-            return _this2.toggleInline();
-          }, checked: checked }),
-        ' show inline errors.',
+        React.createElement(
+          'label',
+          null,
+          React.createElement('input', { type: 'checkbox', onChange: function onChange(e) {
+              return _this2.toggleInline();
+            }, checked: checked }),
+          ' show inline errors.'
+        ),
         React.createElement('hr', null),
         React.createElement(
           'h2',

--- a/example/app.js
+++ b/example/app.js
@@ -49,12 +49,14 @@ class App extends React.Component {
     // used, React throws a controlled/uncontrolled warning... =_=
     var checked = this.state.inlineErrors ? "checked" : false;
 
+    var percentage = parseInt(this.state.ratio * 100);
+
     return (
       <div>
         <h2>An example form:</h2>
         <Form ref="form" {...formProps} />
-        <button onClick={e => this.submitForm(e)}>Submit</button> (<span>{this.state.ratio * 100}%</span> complete)
-        <input type="checkbox" onChange={e => this.toggleInline()} checked={checked} /> show inline errors.
+        <button onClick={e => this.submitForm(e)}>Submit</button> (<span>{percentage}%</span> complete)
+        <label><input type="checkbox" onChange={e => this.toggleInline()} checked={checked} /> show inline errors.</label>
 
         <hr/>
 

--- a/example/fields.js
+++ b/example/fields.js
@@ -2,7 +2,9 @@ module.exports = {
   'avatar': {
     type: "image",
     label: "Select an avatar",
-    fieldClassname: "avatar"
+    fieldClassname: "avatar",
+    prompt: "Pick image",
+    reprompt: "Pick different image"
   },
   'full_name': {
     type: "text",
@@ -47,7 +49,9 @@ module.exports = {
   },
   'email choices': {
     type: "checkbox",
-    label:"I would like to pick the emails you send me",
+    label: "I would like to pick the emails you send me",
+    metered: false,
+    optional: true
   },
   'email cats': {
     type: "checkboxGroup",
@@ -57,9 +61,8 @@ module.exports = {
       name: "email choices",
       value: true
     },
-    validator: {
-      error: "Please pick at least one category of emails you would like to receive."
-    }
+    metered: false,
+    optional: true
   },
   notes: {
     type: "textarea",

--- a/example/fields.js
+++ b/example/fields.js
@@ -1,4 +1,9 @@
 module.exports = {
+  'avatar': {
+    type: "image",
+    label: "Select an avatar",
+    fieldClassname: "avatar"
+  },
   'full_name': {
     type: "text",
     label: "Participant name",

--- a/example/style.css
+++ b/example/style.css
@@ -12,3 +12,9 @@ fieldset textarea, fieldset input[type='text']:not(.multiple) {
 	display: block;
 	width: 20em;
 }
+
+fieldset .avatar.image img {
+	max-width: 200px;
+	max-height: 150px;
+	display: block;
+}

--- a/example/style.css
+++ b/example/style.css
@@ -18,3 +18,8 @@ fieldset .avatar.image img {
 	max-height: 150px;
 	display: block;
 }
+
+fieldset label .optional {
+	color: rgba(0,0,0,0.3);
+	margin-left: 1em;
+}

--- a/src/Form.jsx
+++ b/src/Form.jsx
@@ -131,11 +131,12 @@ var Form = React.createClass({
 
     // Does this field come with an associated label?
     if (label) {
-      label = <label key={name + 'label'} className={labelClass}>{label}</label>;
+      let optional = '';
       // mark optional fields that have a label as being optional:
       if (field.optional) {
-        label = [label, <span key={name + 'label-optional'} > (optional)</span>];
+        optional = <span key={name + 'label-optional'} className="optional">(optional)</span>;
       }
+      label = <label key={name + 'label'} className={labelClass}>{ label }{ optional }</label>;
     } else {
       label = null;
       inputClass += " nolabel";

--- a/src/fields/Image.jsx
+++ b/src/fields/Image.jsx
@@ -4,7 +4,6 @@ var MultiplicityField = require('./MultiplicityField.jsx');
 
 module.exports = React.createClass({
   getInitialState() {
-    console.log(this.props);
     return {
       attachment: false
     }
@@ -12,59 +11,59 @@ module.exports = React.createClass({
 
   render() {
     let props = this.props;
-    let className = (this.props.className || '') + ' image';
+    let field = props.field;
+    let className = ((props.className || '') + ' image').trim();
 
     return (
       <div className={className}>
-        <input type="file" hidden={"hidden"} ref="optionalFile" onChange={e => this.handleFiles(e)}/>
-        { this.generatePicker() }
+        <input type="file" hidden={"hidden"} ref="filePicker" onChange={e => this.handleFiles(e)}/>
+        { this.generatePicker(field.prompt, field.reprompt) }
       </div>
     );
   },
 
-  generatePicker: function() {
+  generatePicker: function(prompt, reprompt) {
     if (!this.state.attachment) {
-      return <input type="button" className="btn attach" onClick={e => this.selectFiles(e)} value="Click here to pick an image" />;
+      prompt = prompt || "Click here to pick an image";
+
+      return <input type="button" className="btn attach" onClick={e => this.selectFiles(e)} value={prompt} />;
     }
+
+    reprompt = reprompt || "Click here to pick a different image";
 
     return [
       <img key='preview' src={"data:image/jpg;base64," + this.state.attachment.base64}/>,
-      <input key='attach' type="button" className="btn reattach" onClick={e => this.selectFiles(e)} value="Click here to pick a different image" />
+      <input key='attach' type="button" className="btn reattach" onClick={e => this.selectFiles(e)} value={reprompt} />
     ];
   },
 
   selectFiles: function() {
-    this.refs.optionalFile.click();
+    this.refs.filePicker.click();
   },
 
   handleFiles: function(evt) {
     var files = evt.target.files;
-
-    var attachment = {};
+    var b64str = 'base64,';
 
     var parse = (file) => {
       var reader = new FileReader();
-      var bootstrap = (f) => {
-        return (e) => {
-          var name = escape(f.name);
-          var data = e.target.result;
-
+      var fileAsBase64 = (selectedFile) => {
+        return (evt) => {
+          var name = escape(selectedFile.name);
+          var data = evt.target.result;
           if (data) {
-            data = data.substring(data.indexOf('base64,')+'base64,'.length);
-            attachment = {
-              name: name,
-              base64: data
-            };
+            var base64 = data.substring(data.indexOf(b64str) + b64str.length);
+            var attachment = { name, base64 };
             this.setState({ attachment }, this.handleImageAttached);
           }
         };
       };
 
-      reader.onload = bootstrap(file);
+      reader.onload = fileAsBase64(file);
       reader.readAsDataURL(file);
     };
 
-    Array.from(files).forEach(parse);
+    parse(Array.from(files).slice(-1)[0]);
   },
 
   handleImageAttached: function() {

--- a/src/fields/Image.jsx
+++ b/src/fields/Image.jsx
@@ -3,15 +3,75 @@ var cleanProps = require("./clean-props");
 var MultiplicityField = require('./MultiplicityField.jsx');
 
 module.exports = React.createClass({
+  getInitialState() {
+    console.log(this.props);
+    return {
+      attachment: false
+    }
+  },
+
   render() {
     let props = this.props;
-    let value = props.value;
+    let className = (this.props.className || '') + ' image';
 
-    if (props.multiplicity) {
-      let values = typeof value === "object" ? value : [value];
-      return <MultiplicityField {...props} values={values} />;
+    return (
+      <div className={className}>
+        <input type="file" hidden={"hidden"} ref="optionalFile" onChange={e => this.handleFiles(e)}/>
+        { this.generatePicker() }
+      </div>
+    );
+  },
+
+  generatePicker: function() {
+    if (!this.state.attachment) {
+      return <input type="button" className="btn attach" onClick={e => this.selectFiles(e)} value="Click here to pick an image" />;
     }
 
-    return <input type="text" {...cleanProps(props)}/>;
+    return [
+      <img key='preview' src={"data:image/jpg;base64," + this.state.attachment.base64}/>,
+      <input key='attach' type="button" className="btn reattach" onClick={e => this.selectFiles(e)} value="Click here to pick a different image" />
+    ];
+  },
+
+  selectFiles: function() {
+    this.refs.optionalFile.click();
+  },
+
+  handleFiles: function(evt) {
+    var files = evt.target.files;
+
+    var attachment = {};
+
+    var parse = (file) => {
+      var reader = new FileReader();
+      var bootstrap = (f) => {
+        return (e) => {
+          var name = escape(f.name);
+          var data = e.target.result;
+
+          if (data) {
+            data = data.substring(data.indexOf('base64,')+'base64,'.length);
+            attachment = {
+              name: name,
+              base64: data
+            };
+            this.setState({ attachment }, this.handleImageAttached);
+          }
+        };
+      };
+
+      reader.onload = bootstrap(file);
+      reader.readAsDataURL(file);
+    };
+
+    Array.from(files).forEach(parse);
+  },
+
+  handleImageAttached: function() {
+    this.props.onChange({
+      target: {
+        value: this.state.attachment
+      }
+    });
   }
 });

--- a/src/fields/field-type.js
+++ b/src/fields/field-type.js
@@ -7,7 +7,7 @@ var validatorPropType = React.PropTypes.shape({
 
 module.exports = React.PropTypes.shape({
   type: React.PropTypes.oneOfType([
-    React.PropTypes.oneOf(['text','textarea','choiceGroup','checkbox','checkboxGroup']),
+    React.PropTypes.oneOf(['image','text','textarea','choiceGroup','checkbox','checkboxGroup']),
     React.PropTypes.func
   ]).isRequired,
   label: React.PropTypes.oneOfType([

--- a/src/fields/field-type.js
+++ b/src/fields/field-type.js
@@ -1,36 +1,41 @@
 var React = require('react');
+var types = React.PropTypes;
 
-var validatorPropType = React.PropTypes.shape({
-  error: React.PropTypes.string,
-  validate: React.PropTypes.func
+var validatorPropType = types.shape({
+  error: types.string,
+  validate: types.func
 });
 
-module.exports = React.PropTypes.shape({
-  type: React.PropTypes.oneOfType([
-    React.PropTypes.oneOf(['image','text','textarea','choiceGroup','checkbox','checkboxGroup']),
-    React.PropTypes.func
+var controllerPropType = {
+  name: types.string,
+  value: types.oneOfType([
+    types.bool,
+    types.number,
+    types.string,
+    types.array,
+    types.object
+  ]),
+};
+
+module.exports = types.shape({
+  type: types.oneOfType([
+    types.oneOf(['image','text','textarea','choiceGroup','checkbox','checkboxGroup']),
+    types.func
   ]).isRequired,
-  label: React.PropTypes.oneOfType([
-    React.PropTypes.string,
-    React.PropTypes.element
+  label: types.oneOfType([
+    types.string,
+    types.element
   ]),
-  placeholder: React.PropTypes.string,
-  validator: React.PropTypes.oneOfType([
+  placeholder: types.string,
+  validator: types.oneOfType([
     validatorPropType,
-    React.PropTypes.arrayOf(validatorPropType)
+    types.arrayOf(validatorPropType)
   ]),
-  metered: React.PropTypes.boolean,
-  optional: React.PropTypes.boolean,
-  controller: React.PropTypes.shape({
-    name: React.PropTypes.string,
-    value: React.PropTypes.oneOfType([
-      React.PropTypes.bool,
-      React.PropTypes.number,
-      React.PropTypes.string,
-      React.PropTypes.array,
-      React.PropTypes.object
-    ]),
-  }),
-  colCount: React.PropTypes.number,
-  multiplicity: React.PropTypes.number
+  metered: types.boolean,
+  optional: types.boolean,
+  controller: types.shape(controllerPropType),
+  colCount: types.number,
+  multiplicity: types.number,  // used by text
+  prompt: types.string,        // used by image
+  reprompt: types.string       // used by image
 });


### PR DESCRIPTION
fixes https://github.com/Pomax/react-formbuilder/issues/17

this adds a `type: "image"` to the set of possible form fields. An image field is shown as a label + a button that says "Click here to pick an image". Clicking this button lets the user pick an image from their computer, after which the image field is shown as the image as `<img>` element with a button that says "Click here to pick a different image"

This might need some refinement, but an early PR means nothing is blocked.